### PR TITLE
Rename privateToken to cachedToken and make it deprecated

### DIFF
--- a/Sources/GReaderSwift/Models/Credentials.swift
+++ b/Sources/GReaderSwift/Models/Credentials.swift
@@ -14,7 +14,8 @@ public final class Credentials {
     
     // MARK: Private vars
     
-    internal var privateToken: String?
+    @available(*, deprecated, message: "Do not use directly, use `token(from:)` instead.")
+    internal var cachedToken: String?
     
     // MARK: - Initializer
     

--- a/Sources/GReaderSwift/Requests/Credentials/Credentials+Token.swift
+++ b/Sources/GReaderSwift/Requests/Credentials/Credentials+Token.swift
@@ -1,11 +1,19 @@
 import Foundation
 
+
+/// Protocol used to remove deprecated warning from using `Credentials.cachedToken`
+fileprivate protocol CredentialsCachedToken: AnyObject {
+    var cachedToken: String? { get set }
+}
+extension Credentials: CredentialsCachedToken {}
+
+
 internal extension Credentials {
     /// Retrieve the token, used for advanced requests, from cache or by performing a request on server
     /// - Returns: The token
     func token() async throws -> String {
         // Return token if already retrieved
-        if let token = privateToken {
+        if let token = (self as CredentialsCachedToken).cachedToken {
             return token
         }
         
@@ -29,7 +37,7 @@ internal extension Credentials {
         }
         
         // Store and return token
-        self.privateToken = token
+        (self as CredentialsCachedToken).cachedToken = token
         return token
     }
 }

--- a/Tests/GReaderSwiftTests/Models/CredentialsCodableTests.swift
+++ b/Tests/GReaderSwiftTests/Models/CredentialsCodableTests.swift
@@ -3,32 +3,32 @@ import Nimble
 import XCTest
 
 final class CredentialsCodableTests: XCTestCase {
-    func test_Encode_ShouldNotEncodePrivateToken() throws {
+    func test_Encode_ShouldNotEncodeCachedToken() throws {
         // Given
         let credentials = Credentials(
             baseURL: URL(string: "https://localhost/api/")!,
             username: "some_username",
             authKey: "some_key"
         )
-        credentials.privateToken = "some_token"
+        credentials.cachedTokenTestAccess = "some_token"
         
         // When
         let json = try JSONEncoder().encode(credentials)
         let jsonString = String(data: json, encoding: .utf8)
         
         // Then
-        expect(jsonString).notTo(contain("privateToken"))
+        expect(jsonString).notTo(contain("cachedToken"))
         expect(jsonString).notTo(contain("some_token"))
     }
     
-    func test_Decode_ShouldNotDecodePrivateToken() throws {
+    func test_Decode_ShouldNotDecodeCachedToken() throws {
         // Given
         let jsonString = """
         {
             "baseURL": "https://localhost/api/",
             "username": "some_username",
             "authKey": "some_key",
-            "privateToken": "some_token",
+            "cachedToken": "some_token",
         }
         """
         
@@ -42,6 +42,6 @@ final class CredentialsCodableTests: XCTestCase {
         expect(credentials.baseURL) == URL(string: "https://localhost/api/")!
         expect(credentials.username) == "some_username"
         expect(credentials.authKey) == "some_key"
-        expect(credentials.privateToken).to(beNil())
+        expect(credentials.cachedTokenTestAccess).to(beNil())
     }
 }

--- a/Tests/GReaderSwiftTests/Requests/Credentials/CredentialsTokenTests.swift
+++ b/Tests/GReaderSwiftTests/Requests/Credentials/CredentialsTokenTests.swift
@@ -32,26 +32,26 @@ final class CredentialsTokenTests: XCTestCase {
         expect(result) == "some_token"
     }
     
-    func test_Token_ShouldSaveTokenIntoPrivateToken_WhenPrivateTokenIsNil() async throws {
+    func test_Token_ShouldSaveTokenIntoCachedToken_WhenChachedTokenIsNil() async throws {
         // Given
         let credentials = Credentials(baseURL: baseURL, username: "username", authKey: "auth_key")
         let mockedResponse = "some_token"
         let mock = mock(response: mockedResponse.data(using: .utf8)!)
         mock.register()
         
-        expect(credentials.privateToken).to(beNil())
+        expect(credentials.cachedTokenTestAccess).to(beNil())
         
         // When
         _ = try await credentials.token()
         
         // Then
-        expect(credentials.privateToken) == "some_token"
+        expect(credentials.cachedTokenTestAccess) == "some_token"
     }
     
-    func test_Token_ShouldReturnPrivateToken_WhenItsValueIsNotNil() async throws {
+    func test_Token_ShouldReturnCachedToken_WhenItsValueIsNotNil() async throws {
         // Given
         let credentials = Credentials(baseURL: baseURL, username: "username", authKey: "auth_key")
-        credentials.privateToken = "some_private_token"
+        credentials.cachedTokenTestAccess = "some_cached_token"
         let mockedResponse = "some_token"
         let mock = mock(response: mockedResponse.data(using: .utf8)!)
         mock.register()
@@ -60,7 +60,7 @@ final class CredentialsTokenTests: XCTestCase {
         let result = try await credentials.token()
         
         // Then
-        expect(result) == "some_private_token"
+        expect(result) == "some_cached_token"
     }
     
     func test_Token_ShouldUseFirstNonEmptyStringAsToken_WhenServerRespondsWithMultipleStringsOnMultipleLines() async throws {

--- a/Tests/GReaderSwiftTests/TestsHelpers/Credentials.swift
+++ b/Tests/GReaderSwiftTests/TestsHelpers/Credentials.swift
@@ -1,0 +1,15 @@
+@testable import GReaderSwift
+
+/// Protocol used to remove deprecated warning from using `Credentials.cachedToken`
+fileprivate protocol CredentialsCachedToken: AnyObject {
+    var cachedToken: String? { get set }
+}
+extension Credentials: CredentialsCachedToken {}
+
+extension Credentials {
+    /// Wrapper around `cachedToken` to prevent warnings when using it
+    var cachedTokenTestAccess: String? {
+        get { (self as CredentialsCachedToken).cachedToken }
+        set { (self as CredentialsCachedToken).cachedToken = newValue }
+    }
+}

--- a/Tests/GReaderSwiftTests/TestsHelpersTests/CredentialsTestsHelperTests.swift
+++ b/Tests/GReaderSwiftTests/TestsHelpersTests/CredentialsTestsHelperTests.swift
@@ -1,0 +1,43 @@
+@testable import GReaderSwift
+import Nimble
+import XCTest
+
+/// Protocol used to remove deprecated warning from using `Credentials.cachedToken`
+fileprivate protocol CredentialsCachedToken: AnyObject {
+    var cachedToken: String? { get set }
+}
+extension Credentials: CredentialsCachedToken {}
+
+class CredentialsTestsHelperTests: XCTestCase {
+    func test_CachedTokenTestAccess_ShouldSetValueOfCachedToken() {
+        // Given
+        let credentials = Credentials(
+            baseURL: URL(string: "https://localhost/api/")!,
+            username: "some_username",
+            authKey: "some_key"
+        )
+        (credentials as CredentialsCachedToken).cachedToken = "old_token"
+        
+        // When
+        credentials.cachedTokenTestAccess = "new_token"
+        
+        // Then
+        expect((credentials as CredentialsCachedToken).cachedToken) == "new_token"
+    }
+    
+    func test_CachedTokenTestAccess_ShouldReturnValueOfCachedToken() {
+        // Given
+        let credentials = Credentials(
+            baseURL: URL(string: "https://localhost/api/")!,
+            username: "some_username",
+            authKey: "some_key"
+        )
+        (credentials as CredentialsCachedToken).cachedToken = "some_token"
+        
+        // When
+        let result = credentials.cachedTokenTestAccess
+        
+        // Then
+        expect(result) == "some_token"
+    }
+}


### PR DESCRIPTION
To prevent using it by mistake